### PR TITLE
[codex] Refactor benchmark execution orchestration

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -13,17 +13,17 @@ def response():
 @pytest.fixture(scope="session")
 def mock_openai():
     with patch("openai.ChatCompletion.create") as mock_create:
-        mock_create.return_value = {"choices": [{"message": {"content": response()}}]}
+        mock_create.return_value = {"choices": [{"message": {"content": mock_response}}]}
         yield mock_create
 
 
 @pytest.fixture(scope="session")
 def mock_together():
-    mock_response = MagicMock()
-    mock_response.choices = [MagicMock(message=MagicMock(content=mock_response))]
+    response_obj = MagicMock()
+    response_obj.choices = [MagicMock(message=MagicMock(content=mock_response))]
 
     mock_client = MagicMock()
-    mock_client.chat.completions.create.return_value = mock_response
+    mock_client.chat.completions.create.return_value = response_obj
 
     with patch("together.Together", return_value=mock_client):
         yield mock_client

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -2,6 +2,24 @@
 
 This directory contains utility scripts for running experiments and managing the project.
 
+## Benchmark runner
+
+`run_benchmark.py` plans and runs paper-style benchmark suites with explicit
+model overrides, repeat-aware output directories, manifest files, and safety
+checks for partial outputs.
+
+Preview the Qwen final-main plan without writing outputs:
+
+```bash
+uv run python scripts/run_benchmark.py --suite final-main --dry-run
+```
+
+Run with API preflight and resume support:
+
+```bash
+uv run python scripts/run_benchmark.py --suite final-main --preflight-api --resume
+```
+
 ## Directories
 
 ### slurm/

--- a/scripts/run_benchmark.py
+++ b/scripts/run_benchmark.py
@@ -1,0 +1,489 @@
+#!/usr/bin/env python3
+"""Plan and run paper-style Thriller benchmark suites."""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import copy
+import json
+import sys
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+import pandas as pd
+import yaml
+from dotenv import load_dotenv
+
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+from src.thriller import bentz, brewer, delatorre, gerrig, lehne
+from src.thriller.Thriller import attach_api_keys, run_config
+from src.thriller.api import generate_response
+
+
+DEFAULT_MODEL = "Qwen/Qwen3.5-9B"
+DEFAULT_EXPERIMENTS = ("gerrig", "delatorre", "lehne", "brewer", "bentz")
+EXPERIMENT_MODULES = {
+    "gerrig": gerrig,
+    "delatorre": delatorre,
+    "lehne": lehne,
+    "brewer": brewer,
+    "bentz": bentz,
+}
+
+
+@dataclass(frozen=True)
+class RunSpec:
+    suite: str
+    experiment: str
+    repeat: int
+    config_path: Path
+    output_dir: Path
+    model: str
+    parse_model: str
+    augmentation_order: tuple[str, ...]
+    source_augmentation_order: tuple[str, ...]
+    expected_rows: int
+    expected_segments: int
+    expected_calls: int
+
+
+@dataclass(frozen=True)
+class BenchmarkPlan:
+    suite: str
+    specs: tuple[RunSpec, ...]
+
+    @property
+    def total_calls(self) -> int:
+        return sum(spec.expected_calls for spec in self.specs)
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def safe_model_dir(model: str) -> str:
+    return model.replace("/", "_")
+
+
+def model_output_dir(spec: RunSpec) -> Path:
+    return spec.output_dir / safe_model_dir(spec.model)
+
+
+def load_yaml(path: Path) -> dict[str, Any]:
+    with open(path, "r") as f:
+        return yaml.safe_load(f)
+
+
+def output_dir_for(experiment: str, repeat: int) -> Path:
+    if experiment == "brewer":
+        return PROJECT_ROOT / "outputs" / "brewer_experiment" / "final" / "paper" / f"exp{repeat}"
+    return PROJECT_ROOT / "outputs" / f"{experiment}_experiment" / "final" / f"e{repeat}"
+
+
+def normalize_experiments(experiments: str | Iterable[str]) -> tuple[str, ...]:
+    if isinstance(experiments, str):
+        requested = tuple(item.strip() for item in experiments.split(",") if item.strip())
+    else:
+        requested = tuple(experiments)
+
+    unknown = sorted(set(requested) - set(DEFAULT_EXPERIMENTS))
+    if unknown:
+        raise ValueError(f"Unknown experiment(s): {', '.join(unknown)}")
+    return requested
+
+
+def count_expected(config: dict[str, Any]) -> tuple[int, int, int]:
+    series = config["experiment"]["experiment_series"]
+    prompts, version_prompts = EXPERIMENT_MODULES[series].generate_experiment_texts(
+        config["experiment"]
+    )
+    rows = sum(len(versions) for versions in version_prompts.values())
+    segments = sum(
+        len(text) if isinstance(text, list) else 1
+        for versions in version_prompts.values()
+        for _, text in versions
+    )
+    calls = segments * 2
+    if len(prompts) != len(version_prompts):
+        raise ValueError(f"Prompt/version mismatch for {series}")
+    return rows, segments, calls
+
+
+def effective_config_for_spec(spec: RunSpec) -> dict[str, Any]:
+    config = load_yaml(spec.config_path)
+    config = copy.deepcopy(config)
+    config["model"]["name"] = spec.model
+    config["parse_model"]["name"] = spec.parse_model
+    config["experiment"]["output_dir"] = str(spec.output_dir)
+    config["augmentation"]["augmentation_order"] = list(spec.augmentation_order)
+    return config
+
+
+def build_run_spec(
+    suite: str,
+    experiment: str,
+    repeat: int,
+    model: str,
+    parse_model: str,
+) -> RunSpec:
+    if suite != "final-main":
+        raise ValueError("Only the final-main suite is currently supported")
+
+    config_path = PROJECT_ROOT / "configs" / f"{experiment}.yaml"
+    source_config = load_yaml(config_path)
+    source_augmentation_order = tuple(
+        source_config["augmentation"].get("augmentation_order", [])
+    )
+
+    effective_config = copy.deepcopy(source_config)
+    effective_config["model"]["name"] = model
+    effective_config["parse_model"]["name"] = parse_model
+    effective_config["experiment"]["output_dir"] = str(output_dir_for(experiment, repeat))
+    effective_config["augmentation"]["augmentation_order"] = []
+
+    rows, segments, calls = count_expected(effective_config)
+    return RunSpec(
+        suite=suite,
+        experiment=experiment,
+        repeat=repeat,
+        config_path=config_path,
+        output_dir=output_dir_for(experiment, repeat),
+        model=model,
+        parse_model=parse_model,
+        augmentation_order=(),
+        source_augmentation_order=source_augmentation_order,
+        expected_rows=rows,
+        expected_segments=segments,
+        expected_calls=calls,
+    )
+
+
+def build_plan(
+    suite: str,
+    experiments: str | Iterable[str],
+    repeats: int,
+    model: str,
+    parse_model: str,
+) -> BenchmarkPlan:
+    requested_experiments = normalize_experiments(experiments)
+    specs = []
+    for repeat in range(1, repeats + 1):
+        for experiment in requested_experiments:
+            specs.append(
+                build_run_spec(
+                    suite=suite,
+                    experiment=experiment,
+                    repeat=repeat,
+                    model=model,
+                    parse_model=parse_model,
+                )
+            )
+    return BenchmarkPlan(suite=suite, specs=tuple(specs))
+
+
+def validate_run_spec(spec: RunSpec) -> None:
+    if spec.suite == "final-main" and spec.augmentation_order:
+        raise ValueError(
+            f"Refusing final-main run with augmentation_order={spec.augmentation_order}"
+        )
+
+
+def manifest_payload(
+    spec: RunSpec,
+    run_dir: Path,
+    status: str,
+    started_at: str,
+    finished_at: str | None,
+    actual_rows: int | None = None,
+) -> dict[str, Any]:
+    payload = asdict(spec)
+    payload["config_path"] = str(spec.config_path)
+    payload["output_dir"] = str(spec.output_dir)
+    payload["run_dir"] = str(run_dir)
+    payload["augmentation_order"] = list(spec.augmentation_order)
+    payload["source_augmentation_order"] = list(spec.source_augmentation_order)
+    payload["status"] = status
+    payload["started_at"] = started_at
+    payload["finished_at"] = finished_at
+    payload["actual_rows"] = actual_rows
+    return payload
+
+
+def manifest_matches_spec(manifest: dict[str, Any], spec: RunSpec) -> bool:
+    return (
+        manifest.get("suite") == spec.suite
+        and manifest.get("experiment") == spec.experiment
+        and manifest.get("repeat") == spec.repeat
+        and manifest.get("model") == spec.model
+        and manifest.get("parse_model") == spec.parse_model
+        and manifest.get("augmentation_order") == list(spec.augmentation_order)
+    )
+
+
+def find_completed_run(spec: RunSpec) -> Path | None:
+    model_dir = model_output_dir(spec)
+    if not model_dir.exists():
+        return None
+
+    completed = []
+    for manifest_path in sorted(model_dir.glob("*/benchmark_manifest.json")):
+        try:
+            with open(manifest_path, "r") as f:
+                manifest = json.load(f)
+        except json.JSONDecodeError:
+            continue
+        run_dir = manifest_path.parent
+        if (
+            manifest_matches_spec(manifest, spec)
+            and manifest.get("status") == "completed"
+            and (run_dir / "results.csv").exists()
+        ):
+            completed.append(run_dir)
+    return completed[-1] if completed else None
+
+
+def existing_run_dirs(spec: RunSpec) -> list[Path]:
+    model_dir = model_output_dir(spec)
+    if not model_dir.exists():
+        return []
+    return sorted(path for path in model_dir.iterdir() if path.is_dir())
+
+
+def ensure_output_state(spec: RunSpec, resume: bool) -> tuple[str, Path | None]:
+    completed = find_completed_run(spec)
+    if completed and resume:
+        return "skip", completed
+    if completed and not resume:
+        raise RuntimeError(
+            f"Completed output already exists for {spec.experiment} repeat {spec.repeat}: "
+            f"{completed}. Use --resume to skip it or quarantine it first."
+        )
+
+    existing = existing_run_dirs(spec)
+    if existing:
+        formatted = "\n".join(f"  - {path}" for path in existing)
+        raise RuntimeError(
+            f"Existing output dirs would make this run ambiguous for "
+            f"{spec.experiment} repeat {spec.repeat}:\n{formatted}\n"
+            "Quarantine or remove them before running."
+        )
+
+    return "run", None
+
+
+def write_manifest(spec: RunSpec, run_dir: Path, started_at: str) -> None:
+    results_csv = run_dir / "results.csv"
+    if not results_csv.exists():
+        raise RuntimeError(f"Missing results.csv for completed run: {run_dir}")
+
+    actual_rows = len(pd.read_csv(results_csv))
+    quality_issues = find_result_quality_issues(results_csv)
+    status = (
+        "completed"
+        if actual_rows == spec.expected_rows and not quality_issues
+        else "failed"
+    )
+    manifest = manifest_payload(
+        spec=spec,
+        run_dir=run_dir,
+        status=status,
+        started_at=started_at,
+        finished_at=utc_now(),
+        actual_rows=actual_rows,
+    )
+    manifest["quality_issues"] = quality_issues
+
+    with open(run_dir / "benchmark_manifest.json", "w") as f:
+        json.dump(manifest, f, indent=2)
+
+    if actual_rows != spec.expected_rows:
+        raise RuntimeError(
+            f"Unexpected row count for {run_dir}: expected {spec.expected_rows}, "
+            f"got {actual_rows}"
+        )
+
+    if quality_issues:
+        raise RuntimeError(
+            f"Result quality check failed for {run_dir}: "
+            f"{len(quality_issues)} issue(s)"
+        )
+
+
+def find_result_quality_issues(results_csv: Path) -> list[dict[str, Any]]:
+    issues = []
+    df = pd.read_csv(results_csv)
+    for row_index, row in df.iterrows():
+        try:
+            parsed = ast.literal_eval(row["response"])
+        except (SyntaxError, ValueError) as exc:
+            issues.append(
+                {
+                    "row": int(row_index),
+                    "experiment_name": row.get("experiment_name"),
+                    "version": row.get("version"),
+                    "error": f"unparseable response: {exc}",
+                }
+            )
+            continue
+
+        bad_values = {
+            key: value
+            for key, value in parsed.items()
+            if value is None or pd.isna(value)
+        }
+        if bad_values:
+            issues.append(
+                {
+                    "row": int(row_index),
+                    "experiment_name": row.get("experiment_name"),
+                    "version": row.get("version"),
+                    "bad_values": bad_values,
+                }
+            )
+    return issues
+
+
+def print_plan(plan: BenchmarkPlan) -> None:
+    print(f"Benchmark suite: {plan.suite}")
+    print(f"Runs: {len(plan.specs)}")
+    print(f"Estimated calls: {plan.total_calls}")
+    for spec in plan.specs:
+        source_note = ""
+        if spec.source_augmentation_order != spec.augmentation_order:
+            source_note = (
+                f" source_aug={list(spec.source_augmentation_order)}"
+                f" -> effective_aug={list(spec.augmentation_order)}"
+            )
+        print(
+            f"- {spec.experiment} repeat={spec.repeat} rows={spec.expected_rows} "
+            f"segments={spec.expected_segments} calls={spec.expected_calls} "
+            f"model={spec.model} parse_model={spec.parse_model} "
+            f"output={spec.output_dir}{source_note}"
+        )
+
+
+def preflight_api(plan: BenchmarkPlan) -> None:
+    if not plan.specs:
+        return
+
+    first_config = effective_config_for_spec(plan.specs[0])
+    attach_api_keys(first_config["model"], first_config["parse_model"])
+
+    configs = [
+        ("model", first_config["model"]),
+        ("parse_model", first_config["parse_model"]),
+    ]
+    seen = set()
+    for label, model_config in configs:
+        model_id = (model_config["api_type"], model_config["name"])
+        if model_id in seen:
+            continue
+        seen.add(model_id)
+        response = generate_response(
+            [
+                {"role": "system", "content": "Return only the number 7."},
+                {"role": "user", "content": "Return only the number 7."},
+            ],
+            model_config,
+        )
+        if not response or "7" not in response:
+            raise RuntimeError(
+                f"Preflight failed for {label} {model_config['name']}: {response!r}"
+            )
+        print(f"Preflight OK: {label} {model_config['name']}")
+
+
+def execute_plan(
+    plan: BenchmarkPlan,
+    dry_run: bool,
+    resume: bool,
+    preflight: bool,
+    write_prompts: bool,
+) -> None:
+    for spec in plan.specs:
+        validate_run_spec(spec)
+
+    print_plan(plan)
+    if dry_run:
+        return
+
+    if preflight:
+        preflight_api(plan)
+
+    for index, spec in enumerate(plan.specs, start=1):
+        action, completed = ensure_output_state(spec, resume=resume)
+        if action == "skip":
+            print(
+                f"[{index}/{len(plan.specs)}] Skipping completed "
+                f"{spec.experiment} repeat {spec.repeat}: {completed}"
+            )
+            continue
+
+        print(
+            f"[{index}/{len(plan.specs)}] Running {spec.experiment} "
+            f"repeat {spec.repeat}"
+        )
+        config = effective_config_for_spec(spec)
+        started_at = utc_now()
+        output_paths = run_config(
+            config=config,
+            write_prompts=write_prompts,
+            dry_run=False,
+        )
+        if len(output_paths) != 1:
+            raise RuntimeError(
+                f"Expected exactly one output path for {spec.experiment}, "
+                f"got {len(output_paths)}"
+            )
+        write_manifest(spec, output_paths[0], started_at)
+
+
+def parse_arguments(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Run Thriller benchmark suites")
+    parser.add_argument("--suite", default="final-main", choices=["final-main"])
+    parser.add_argument("--experiments", default=",".join(DEFAULT_EXPERIMENTS))
+    parser.add_argument("--repeats", type=int, default=3)
+    parser.add_argument("--model", default=DEFAULT_MODEL)
+    parser.add_argument("--parse-model", default=DEFAULT_MODEL)
+    parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument("--resume", action="store_true")
+    parser.add_argument("--preflight-api", action="store_true")
+    parser.add_argument(
+        "--write-prompts",
+        action="store_true",
+        help="Write prompt snapshots under prompts/ during execution.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> None:
+    load_dotenv(PROJECT_ROOT / ".env")
+    args = parse_arguments(argv)
+    if args.repeats < 1:
+        raise ValueError("--repeats must be >= 1")
+
+    plan = build_plan(
+        suite=args.suite,
+        experiments=args.experiments,
+        repeats=args.repeats,
+        model=args.model,
+        parse_model=args.parse_model,
+    )
+    execute_plan(
+        plan=plan,
+        dry_run=args.dry_run,
+        resume=args.resume,
+        preflight=args.preflight_api,
+        write_prompts=args.write_prompts,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/thriller/Thriller.py
+++ b/src/thriller/Thriller.py
@@ -7,6 +7,8 @@ Use Example:
 """
 
 import argparse
+import copy
+from dataclasses import dataclass
 import os
 import sys
 from pathlib import Path
@@ -41,17 +43,70 @@ import src.thriller.delatorre as delatorre
 import src.thriller.bentz as bentz
 
 
-def main(args):
-    logging.basicConfig(level=logging.WARNING)
+EXPERIMENT_MODULES = {
+    "gerrig": gerrig,
+    "lehne": lehne,
+    "brewer": brewer,
+    "delatorre": delatorre,
+    "bentz": bentz,
+}
 
-    # Load configuration if provided
-    config = load_config(args) if args.config else {}
+API_KEY_ENV_VARS = {
+    "together": "TOGETHER_API_KEY",
+    "openai": "OPENAI_API_KEY",
+    "anthropic": "ANTHROPIC_API_KEY",
+}
 
-    # Load model and experiment configurations from the configuration file
+
+@dataclass
+class PreparedExperiment:
+    model_config: dict
+    parse_model_config: dict
+    experiment_config: dict
+    augmentation_config: dict
+    experiment_series: str
+    prompts: dict
+    version_prompts: dict
+
+
+def attach_api_key(model_config: dict, label: str) -> None:
+    api_type = model_config.get("api_type")
+    if not api_type:
+        raise ValueError(f"API type not specified in the {label} configuration")
+
+    env_var = API_KEY_ENV_VARS.get(api_type)
+    if not env_var:
+        raise ValueError(
+            f"Unsupported API type in the {label} configuration: {api_type}"
+        )
+
+    api_key = os.getenv(env_var)
+    if not api_key:
+        raise ValueError(f"API key for {api_type} must be provided via {env_var}")
+
+    model_config["api_key"] = api_key
+
+
+def attach_api_keys(model_config: dict, parse_model_config: dict) -> None:
+    attach_api_key(model_config, "model")
+    attach_api_key(parse_model_config, "parse_model")
+
+
+def get_experiment_module(experiment_series: str):
+    experiment = EXPERIMENT_MODULES.get(experiment_series)
+    if not experiment:
+        valid = ", ".join(sorted(EXPERIMENT_MODULES))
+        raise ValueError(f"Valid experiment series not found (must be one of: {valid})")
+    return experiment
+
+
+def prepare_experiment_config(config: dict) -> PreparedExperiment:
+    config = copy.deepcopy(config)
     model_config = config.get("model", None)
     experiment_config = config.get("experiment", None)
     parse_model_config = config.get("parse_model", None)
     augmentation_config = config.get("augmentation", None)
+
     if model_config is None:
         raise ValueError("Model configuration not found in the configuration file")
     if parse_model_config is None:
@@ -61,108 +116,101 @@ def main(args):
     if augmentation_config is None:
         raise ValueError("Augmentation configuration not found in the configuration file")
 
-    # Load API key from secret .env file for model
-    model_api_key = ""
-    model_api_type = model_config.get("api_type")
-    if not model_api_type:
-        raise ValueError("API type not specified in the configuration")
-    if model_api_type == "together":
-        model_api_key = os.getenv("TOGETHER_API_KEY")
-        if not model_api_key:
-            raise ValueError("API key for TogetherAI must be provided in the .env file")
-    elif model_api_type == "openai":
-        model_api_key = os.getenv("OPENAI_API_KEY")
-        if not model_api_key:
-            raise ValueError("API key for OpenAI must be provided in the .env file")
-    elif model_api_type == "anthropic":
-        model_api_key = os.getenv("ANTHROPIC_API_KEY")
-        if not model_api_key:
-            raise ValueError("API key for Anthropic must be provided in the .env file")
-    else:
-        raise ValueError("API type must be provided in the configuration file")
-    model_config["api_key"] = model_api_key
+    attach_api_keys(model_config, parse_model_config)
 
-    # Load API key from secret .env file for parse model
-    parse_model_api_key = ""
-    parse_model_api_type = parse_model_config.get("api_type")
-    if parse_model_api_type == "together":
-        parse_model_api_key = os.getenv("TOGETHER_API_KEY")
-        if not parse_model_api_key:
-            raise ValueError("API key for TogetherAI must be provided in the .env file")
-    elif parse_model_api_type == "openai":
-        parse_model_api_key = os.getenv("OPENAI_API_KEY")
-        if not parse_model_api_key:
-            raise ValueError("API key for OpenAI must be provided in the .env file")
-    elif parse_model_api_type == "anthropic":
-        parse_model_api_key = os.getenv("ANTHROPIC_API_KEY")
-        if not parse_model_api_key:
-            raise ValueError("API key for Anthropic must be provided in the .env file")
-    else:
-        raise ValueError("API type must be provided in the configuration file")
-    parse_model_config["api_key"] = parse_model_api_key
-
-    # Ensure output directory exists
-    output_path = Path(experiment_config["output_dir"])
-    output_path.mkdir(parents=True, exist_ok=True)
-
-    # Determine experiment series
-    experiment = None
     experiment_series = experiment_config.get("experiment_series")
-    if experiment_series == "gerrig":
-        experiment = gerrig
-    elif experiment_series == "lehne":
-        experiment = lehne
-    elif experiment_series == "brewer":
-        experiment = brewer
-    elif experiment_series == "delatorre":
-        experiment = delatorre
-    elif experiment_series == "bentz":
-        experiment = bentz
-    if not experiment:
-        raise ValueError("Valid experiment series not found (must be gerrig, lehne, or delatorre)")
-
-    # Generate experiment texts
-    prompts, version_prompts = experiment.generate_experiment_texts(experiment_config)
+    experiment_module = get_experiment_module(experiment_series)
+    prompts, version_prompts = experiment_module.generate_experiment_texts(
+        experiment_config
+    )
 
     augmentation_config = get_default_augmentation_config() | augmentation_config
+    augmentation_order = augmentation_config.get("augmentation_order", [])
 
-    # Augmentation needs to be done here
-    # Each experiment key is a list of tuples
-    for experiment in version_prompts:
-        version_prompts[experiment] = [(key, process_and_augment_stories(story, augmentation_config)) for key, story in version_prompts[experiment]]
-        if 'caesar_cipher' in augmentation_config.get('augmentation_order', {}):
-            prompts[experiment] = prompts[experiment] + "\nThis text has been encrypted using a Caesar cipher with a step of 3."
+    for exp_name in version_prompts:
+        version_prompts[exp_name] = [
+            (key, process_and_augment_stories(story, augmentation_config))
+            for key, story in version_prompts[exp_name]
+        ]
+        if "caesar_cipher" in augmentation_order:
+            prompts[exp_name] = (
+                prompts[exp_name]
+                + "\nThis text has been encrypted using a Caesar cipher with a step of 3."
+            )
 
-    # print(version_prompts['Experiment'])
-    # exit()
-    if os.environ["DRY_RUN"] and os.environ["DRY_RUN"] == "1":
-        print("Dry run enabled. Skipping experiment execution.")
-        print("Prompts saved to file. Exiting.")
-        exit(0)
+    return PreparedExperiment(
+        model_config=model_config,
+        parse_model_config=parse_model_config,
+        experiment_config=experiment_config,
+        augmentation_config=augmentation_config,
+        experiment_series=experiment_series,
+        prompts=prompts,
+        version_prompts=version_prompts,
+    )
 
-    # Save the prompts to a file
-    augmentation = augmentation_config.get("augmentation_order", [])
-    augmentation = "control" if augmentation[0] == "" else augmentation[0]
-    for experiment in version_prompts:
-        filename = f"prompts/{experiment_series}/{augmentation}/{experiment}.json"
-        os.makedirs(os.path.dirname(filename), exist_ok=True)
-        j = {"prompts": prompts[experiment], "version_prompts": version_prompts[experiment]}
-        with open(filename, "w"):
-            json.dump(j, open(filename, "w"))
-    
 
-    # Run the experiment
+def write_prompt_snapshots(
+    experiment_series: str,
+    prompts: dict,
+    version_prompts: dict,
+    augmentation_config: dict,
+    prompt_root: Path = Path("prompts"),
+) -> None:
+    augmentation_order = augmentation_config.get("augmentation_order", [])
+    augmentation = augmentation_order[0] if augmentation_order else "control"
+    augmentation = "control" if augmentation == "" else augmentation
+
+    for exp_name in version_prompts:
+        filename = prompt_root / experiment_series / augmentation / f"{exp_name}.json"
+        filename.parent.mkdir(parents=True, exist_ok=True)
+        snapshot = {
+            "prompts": prompts[exp_name],
+            "version_prompts": version_prompts[exp_name],
+        }
+        with open(filename, "w") as f:
+            json.dump(snapshot, f)
+
+
+def get_model_names(model_config: dict) -> list[str]:
     model_names = model_config.get("name")
-    total_models = len(model_names)
+    if isinstance(model_names, str):
+        return [model_names]
+    return list(model_names)
 
-    with tqdm(total=total_models, desc="Overall Progress") as pbar:
+
+def run_config(
+    config: dict,
+    write_prompts: bool = True,
+    dry_run: bool = False,
+) -> list[Path]:
+    prepared = prepare_experiment_config(config)
+
+    if write_prompts:
+        write_prompt_snapshots(
+            experiment_series=prepared.experiment_series,
+            prompts=prepared.prompts,
+            version_prompts=prepared.version_prompts,
+            augmentation_config=prepared.augmentation_config,
+        )
+
+    if dry_run:
+        print("Dry run enabled. Skipping experiment execution.")
+        if write_prompts:
+            print("Prompts saved to file. Exiting.")
+        else:
+            print("Prompt snapshots disabled. Exiting.")
+        return []
+
+    output_path = Path(prepared.experiment_config["output_dir"])
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    model_names = get_model_names(prepared.model_config)
+    output_paths = []
+    with tqdm(total=len(model_names), desc="Overall Progress") as pbar:
         for model_name in model_names:
-            cur_model_config = model_config.copy()
+            cur_model_config = prepared.model_config.copy()
             cur_model_config["name"] = model_name
-            # Generate a unique experiment ID for each model run
             experiment_id = generate_experiment_id()
-
-            # Create a subfolder structure: model_name/experiment_id
             cur_output_path = output_path / model_name.replace("/", "_") / experiment_id
             cur_output_path.mkdir(parents=True, exist_ok=True)
 
@@ -170,17 +218,25 @@ def main(args):
             results = run_experiment(
                 output_path=cur_output_path,
                 model_config=cur_model_config,
-                parse_model_config=parse_model_config,
-                prompts=prompts,
-                version_prompts=version_prompts,
+                parse_model_config=prepared.parse_model_config,
+                prompts=prepared.prompts,
+                version_prompts=prepared.version_prompts,
             )
 
-            # Process and save results
             process_and_save_results(results, cur_output_path)
+            output_paths.append(cur_output_path)
 
             pbar.update(1)
 
     tqdm.write("\nExperiment completed successfully!")
+    return output_paths
+
+
+def main(args):
+    logging.basicConfig(level=logging.WARNING)
+    config = load_config(args) if args.config else {}
+    dry_run = os.getenv("DRY_RUN") == "1"
+    run_config(config, write_prompts=not dry_run, dry_run=dry_run)
 
 
 def parse_arguments():

--- a/src/thriller/adversarial.py
+++ b/src/thriller/adversarial.py
@@ -1,52 +1,91 @@
 import random
-import numpy as np
-import string
-import spacy
-import nlpaug.augmenter.word as naw
-import nlpaug.augmenter.char as nac
-from vaderSentiment.vaderSentiment import SentimentIntensityAnalyzer
-from textattack.transformations import (
-    WordSwapEmbedding,
-    WordSwapHomoglyphSwap,
-    WordSwapRandomCharacterSubstitution,
-    BackTranslation
-)
-from textattack.augmentation import Augmenter
-from textattack.shared.attacked_text import AttackedText
-import logging
-from typing import List, Dict, Any, Union
-import torch
 import difflib
-import textattack
-from .misc import generate_response
+import importlib
+import logging
 import re
+import string
+from typing import List, Dict, Any, Union
 
-import nltk
-nltk.download('averaged_perceptron_tagger_eng', quiet=True)
-nltk.download("punkt_tab", quiet=True)
+import numpy as np
+
+from .misc import generate_response
 
 # Initialize logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-# Load spaCy model
-nlp = spacy.load('en_core_web_sm')
+_nlp = None
+_sentiment_analyzer = None
 
-# Initialize sentiment analyzer
-analyzer = SentimentIntensityAnalyzer()
+
+def _require_module(module_name: str, feature: str, install_hint: str):
+    try:
+        return importlib.import_module(module_name)
+    except ImportError as exc:
+        raise ImportError(
+            f"{feature} requires the optional dependency '{module_name}'. "
+            f"Install it with `{install_hint}`."
+        ) from exc
+
+
+def _get_spacy_model():
+    global _nlp
+    if _nlp is None:
+        spacy = _require_module("spacy", "spaCy-based augmentations", "uv run --extra nlp python -m spacy download en_core_web_sm")
+        try:
+            _nlp = spacy.load("en_core_web_sm")
+        except OSError as exc:
+            raise RuntimeError(
+                "spaCy-based augmentations require the 'en_core_web_sm' model. "
+                "Install it with `uv run --extra nlp python -m spacy download en_core_web_sm`."
+            ) from exc
+    return _nlp
+
+
+def _get_sentiment_analyzer():
+    global _sentiment_analyzer
+    if _sentiment_analyzer is None:
+        sentiment_module = _require_module(
+            "vaderSentiment.vaderSentiment",
+            "context_removal",
+            "uv run --extra nlp pytest tests/",
+        )
+        _sentiment_analyzer = sentiment_module.SentimentIntensityAnalyzer()
+    return _sentiment_analyzer
+
+
+def _get_nltk():
+    nltk = _require_module("nltk", "swap_words", "uv run --extra nlp pytest tests/")
+    nltk.download("punkt_tab", quiet=True)
+    return nltk
 
 # Set random seed for reproducibility
 def set_random_seed(seed: int):
     random.seed(seed)
     np.random.seed(seed)
-    torch.manual_seed(seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(seed)
-    textattack.shared.utils.set_seed(seed)
+    try:
+        torch = importlib.import_module("torch")
+    except ImportError:
+        torch = None
+    if torch is not None:
+        torch.manual_seed(seed)
+        if torch.cuda.is_available():
+            torch.cuda.manual_seed_all(seed)
+    try:
+        textattack = importlib.import_module("textattack")
+    except ImportError:
+        textattack = None
+    if textattack is not None:
+        textattack.shared.utils.set_seed(seed)
 set_random_seed(42)
 
 
 def apply_synonym_replacement(text: str, params: dict) -> tuple:
+    naw = _require_module(
+        "nlpaug.augmenter.word",
+        "synonym_replacement",
+        "uv pip install nlpaug",
+    )
     aug = naw.SynonymAug(
         aug_src=params.get('aug_src', 'wordnet'),
         aug_p=params.get('aug_p', 0.3),
@@ -75,6 +114,11 @@ def apply_synonym_replacement(text: str, params: dict) -> tuple:
 
 
 def apply_antonym_replacement(text: str, params: dict) -> str:
+    naw = _require_module(
+        "nlpaug.augmenter.word",
+        "antonym_replacement",
+        "uv pip install nlpaug",
+    )
     aug = naw.AntonymAug(
         aug_p=params.get('aug_p', 0.1),
         aug_min=params.get('aug_min', 1),
@@ -88,6 +132,11 @@ def apply_antonym_replacement(text: str, params: dict) -> str:
 
 
 def apply_introduce_typos(text: str, params: dict) -> str:
+    nac = _require_module(
+        "nlpaug.augmenter.char",
+        "introduce_typos",
+        "uv pip install nlpaug",
+    )
     typo_aug = nac.KeyboardAug(
         aug_char_p=params.get('aug_char_p', 0.1),
         aug_word_p=params.get('aug_word_p', 0.3),
@@ -106,6 +155,7 @@ def apply_introduce_typos(text: str, params: dict) -> str:
 
 def apply_change_character_names(text: str, params: dict) -> str:
     name_list = params.get('name_list', ['Alex', 'Jordan', 'Taylor', 'Riley', 'Morgan'])
+    nlp = _get_spacy_model()
     doc = nlp(text)
     names_in_text = {ent.text for ent in doc.ents if ent.label_ == 'PERSON'}
     name_mapping = {name: random.choice(name_list) for name in names_in_text}
@@ -140,6 +190,8 @@ def apply_shuffle_sentences(text: str, params: dict) -> str:
 
 def apply_context_removal(text: str, params: dict) -> str:
     threshold = params.get('sentiment_threshold', 0.5)
+    nlp = _get_spacy_model()
+    analyzer = _get_sentiment_analyzer()
     doc = nlp(text)
     new_sentences = []
     for sent in doc.sents:
@@ -150,30 +202,56 @@ def apply_context_removal(text: str, params: dict) -> str:
 
 
 def apply_word_swap_embedding(text: str, params: dict) -> str:
-    transformation = WordSwapEmbedding(
-        max_candidates=params.get('max_candidates', 5)
+    textattack_transformations = _require_module(
+        "textattack.transformations",
+        "word_swap_embedding",
+        "uv pip install textattack",
+    )
+    textattack_augmentation = _require_module(
+        "textattack.augmentation",
+        "word_swap_embedding",
+        "uv pip install textattack",
     )
     pct_words_to_swap = params.get('pct_words_to_swap', 0.1)
 
-    augmenter = Augmenter(transformation=transformation, pct_words_to_swap=pct_words_to_swap)
+    transformation = textattack_transformations.WordSwapEmbedding(
+        max_candidates=params.get('max_candidates', 5)
+    )
+    augmenter = textattack_augmentation.Augmenter(
+        transformation=transformation,
+        pct_words_to_swap=pct_words_to_swap,
+    )
     augmented_text = augmenter.augment(text)
     
-    while type(augmented_text) != str:
+    while not isinstance(augmented_text, str):
         augmented_text = augmented_text[0]
 
     return augmented_text
 
 
 def apply_word_swap_homoglyph(text: str, params: dict) -> str:
+    textattack_transformations = _require_module(
+        "textattack.transformations",
+        "word_swap_homoglyph",
+        "uv pip install textattack",
+    )
+    textattack_augmentation = _require_module(
+        "textattack.augmentation",
+        "word_swap_homoglyph",
+        "uv pip install textattack",
+    )
     # Initialize without unsupported parameters
-    transformation = WordSwapHomoglyphSwap()  # No parameters here
+    transformation = textattack_transformations.WordSwapHomoglyphSwap()
     
     pct_words_to_swap = params.get('pct_words_to_swap', 0.1)
 
-    augmenter = Augmenter(transformation=transformation, pct_words_to_swap=pct_words_to_swap)
+    augmenter = textattack_augmentation.Augmenter(
+        transformation=transformation,
+        pct_words_to_swap=pct_words_to_swap,
+    )
     augmented_text = augmenter.augment(text)
 
-    while type(augmented_text) != str:
+    while not isinstance(augmented_text, str):
         augmented_text = augmented_text[0]
 
     return augmented_text
@@ -193,11 +271,21 @@ def apply_sentence_paraphrase(text: str, params: dict) -> str:
 
 
 def apply_backtranslation(text: str, params: dict) -> str:
-    transformation = BackTranslation(
+    textattack_transformations = _require_module(
+        "textattack.transformations",
+        "backtranslation",
+        "uv pip install textattack",
+    )
+    textattack_attacked_text = _require_module(
+        "textattack.shared.attacked_text",
+        "backtranslation",
+        "uv pip install textattack",
+    )
+    transformation = textattack_transformations.BackTranslation(
         src_lang=params.get('src_lang', 'en'),
         target_lang=params.get('target_lang', 'fr')
     )
-    attacked_text = AttackedText(text)
+    attacked_text = textattack_attacked_text.AttackedText(text)
     transformed_texts = transformation(attacked_text)
     if transformed_texts:
         return transformed_texts[0].text  # Get the first transformed text
@@ -258,6 +346,7 @@ def apply_caesar(text: str, params : dict) -> str:
 
   
 def swap_words_in_sentences(text: str, params: dict)  -> str:
+    nltk = _get_nltk()
     sentences = nltk.sent_tokenize(text)
     swapped_sentences = []
     num_swaps = params.get('num_swaps', 2)

--- a/src/thriller/api.py
+++ b/src/thriller/api.py
@@ -9,6 +9,51 @@ from together import Together
 import tiktoken
 
 
+def _optional_request_args(
+    model_config: dict[str, typing.Any], keys: tuple[str, ...]
+) -> dict[str, typing.Any]:
+    return {
+        key: model_config[key]
+        for key in keys
+        if key in model_config and model_config[key] is not None
+    }
+
+
+def _extract_choice_content(response) -> str:
+    if isinstance(response, dict):
+        return response["choices"][0]["message"]["content"]
+
+    choices = getattr(response, "choices", None)
+    if choices:
+        choice = choices[0]
+        message = getattr(choice, "message", None)
+        if message is not None:
+            content = getattr(message, "content", None)
+            if isinstance(content, str):
+                return content
+
+        delta = getattr(choice, "delta", None)
+        if delta is not None:
+            content = getattr(delta, "content", None)
+            if isinstance(content, str):
+                return content
+
+    content = ""
+    try:
+        iterator = iter(response)
+    except TypeError:
+        return content
+
+    for chunk in iterator:
+        chunk_choices = getattr(chunk, "choices", None)
+        if not chunk_choices:
+            continue
+        delta = getattr(chunk_choices[0], "delta", None)
+        content += getattr(delta, "content", "") or ""
+
+    return content
+
+
 def generate_response(
     messages: list[dict[str, str]], model_config: dict[str, typing.Any]
 ) -> str:
@@ -32,12 +77,10 @@ def generate_response(
             messages=messages,
             max_tokens=model_config["max_tokens"],
             temperature=model_config["temperature"],
-            top_p=model_config.get("top_p", None),
-            top_k=model_config.get("top_k", None),
-            repetition_penalty=model_config["repetition_penalty"],
+            **_optional_request_args(model_config, ("top_p", "stop")),
         )
 
-        return response["choices"][0]["message"]["content"]
+        return _extract_choice_content(response)
 
     elif api_type == "together":
         client = Together(api_key=model_config["api_key"])
@@ -46,29 +89,12 @@ def generate_response(
             messages=messages,
             max_tokens=model_config["max_tokens"],
             temperature=model_config["temperature"],
-            top_p=model_config.get("top_p", None),
-            top_k=model_config.get("top_k", None),
-            repetition_penalty=model_config["repetition_penalty"],
-            stop=model_config["stop"],
-            stream=model_config["stream"],
+            **_optional_request_args(
+                model_config,
+                ("top_p", "top_k", "repetition_penalty", "stop", "stream"),
+            ),
         )
-        content = ""
-        try:
-            for chunk in response:
-                if chunk.choices and 'finish_reason' in chunk.choices[0]:
-                    finish_reason = chunk.choices[0].finish_reason
-                    if finish_reason not in ['length', 'stop', 'eos', 'tool_calls', 'error']:
-                        print(f"Invalid finish_reason: {finish_reason}")
-                        finish_reason = 'eos'
-                content += getattr(chunk.choices[0].delta, 'content', '') or "" 
-        except AttributeError as e:
-            print("AttributeError encountered:", e)
-        except IndexError as e:
-            print("IndexError encountered:", e)
-        except Exception as e:
-            print("An error occurred:", e)
-
-        return content
+        return _extract_choice_content(response)
 
     else:
         raise ValueError(f"Unsupported API type: {api_type}")

--- a/src/thriller/brewer.py
+++ b/src/thriller/brewer.py
@@ -167,7 +167,6 @@ def generate_experiment_texts(settings_config: dict[str, str]):
         Experiment prompts and version prompts
     """
     experiment_A_prompt_chunks = common_prompt_template_in_between
-    experiment_A_prompt_full = common_prompt_template_final
 
     prompts = {
         "Experiment A Chunks": experiment_A_prompt_chunks,

--- a/src/thriller/data_collector.py
+++ b/src/thriller/data_collector.py
@@ -83,12 +83,12 @@ def validate_response(value: int, valid_range: tuple) -> tuple[int, bool]:
     logger.debug(f"Validating response: {value} against range {valid_range}")
 
     if value is None:
-        logger.warning(f"Received None value for validation.")
+        logger.warning("Received None value for validation.")
         return None, False
     
     try:
         if np.isnan(value):  # Ensure value is checked safely
-            logger.warning(f"Received NaN value for validation.")
+            logger.warning("Received NaN value for validation.")
             return None, False
     except TypeError:
         logger.warning(f"TypeError: Value {value} is not a number.")

--- a/src/thriller/gerrig.py
+++ b/src/thriller/gerrig.py
@@ -85,11 +85,14 @@ def generate_experiment_texts(experiment_config: dict[str, str]):
     Return:
         Experiment prompts and version prompts
     """
-    substitutions = (
-        alternative_substitutions
-        if experiment_config["use_alternative"]
-        else default_substitutions
-    )
+    if "use_alternative" in experiment_config:
+        substitutions = (
+            alternative_substitutions
+            if experiment_config.get("use_alternative")
+            else default_substitutions
+        )
+    else:
+        substitutions = experiment_config
 
     # Get experiment prompts
 

--- a/src/thriller/misc.py
+++ b/src/thriller/misc.py
@@ -4,13 +4,10 @@ Code that is explicitly related to the execution and parsing of API calls for ex
 # Note: Consider refactoring - these functions could be reorganized into api.py and utils.py
 
 import sys
-import os
 import typing
 from typing import Union
 from pathlib import Path
 from src.thriller.api import generate_response, save_raw_api_output
-import openai
-from together import Together
 import re
 from tqdm import tqdm
 import logging
@@ -55,40 +52,10 @@ def parse_response(
         {"role": "user", "content": response},
     ]
 
-    content = ""
-
-    if api_type == "openai":
-        parsed_response = openai.ChatCompletion.create(
-            model=model_config["name"],
-            messages=messages,
-            max_tokens=model_config["max_tokens"],
-            temperature=model_config["temperature"],
-            top_p=model_config.get("top_p", None),
-            top_k=model_config.get("top_k", None),
-            repetition_penalty=model_config["repetition_penalty"],
-        )
-
-        content = parsed_response["choices"][0]["message"]["content"]
-
-    elif api_type == "together":
-        client = Together(api_key=model_config["api_key"])
-        parsed_response = client.chat.completions.create(
-            model=model_config["name"],
-            messages=messages,
-            max_tokens=model_config["max_tokens"],
-            temperature=model_config["temperature"],
-            top_p=model_config.get("top_p", None),
-            top_k=model_config.get("top_k", None),
-            repetition_penalty=model_config["repetition_penalty"],
-            stop=model_config["stop"],
-            stream=model_config["stream"],
-        )
-
-        for chunk in parsed_response:
-            content += chunk.choices[0].delta.content or ""
-
-    else:
+    if api_type not in {"openai", "together"}:
         raise ValueError(f"Unsupported API type: {api_type}")
+
+    content = generate_response(messages, model_config)
 
     if not content:
         return {}
@@ -177,6 +144,7 @@ def run_experiment(
                             messages.append({"role": "user", "content": prompt + paragraph})
 
                             raw_response = ""
+                            last_error = None
 
                             # Try get LLM response. If context window too large, retry with 1 less message
                             for _ in range(10):
@@ -186,18 +154,27 @@ def run_experiment(
                                         messages, model_config
                                     )
                                     break
-                                except Exception as e:
+                                except Exception as exc:
                                     # logging.error(f"Error occurred: {e}") # This is almost guaranteed to spam
+                                    last_error = exc
                                     if len(messages) >= 4:
                                         messages.pop(1)
                                         messages.pop(1)
                                     else:
-                                       break
+                                        raise RuntimeError(
+                                            f"Failed to get response for {exp_name} "
+                                            f"segment {i} version: {version_name}"
+                                        ) from exc
 
                             parsed_response = {"value": float("nan")}
                             if not raw_response or raw_response.isspace():
-                                raw_response = "Error - No Response: Input Too Long"
-                                print(f"Failed to get response for {exp_name} segment {i} version: {version_name}. Input Too Long")
+                                if last_error is not None:
+                                    raise RuntimeError(
+                                        f"Failed to get response for {exp_name} "
+                                        f"segment {i} version: {version_name}"
+                                    ) from last_error
+                                raw_response = "Error - No Response: Empty Response"
+                                print(f"Failed to get response for {exp_name} segment {i} version: {version_name}. Empty Response")
                             else:
                                 parsed_response = parse_response(
                                     raw_response, parse_model_config

--- a/src/thriller/utils.py
+++ b/src/thriller/utils.py
@@ -5,12 +5,13 @@ Functions related to file I/O such as loading configuration files and saving out
 from argparse import Namespace
 import io
 import json
+import os
 from pathlib import Path
+from typing import Union
 import pandas as pd
 import yaml
 from datetime import datetime
 import uuid
-import unicodedata as ud
 import ast
 
 
@@ -21,13 +22,16 @@ def save_test_output(test_name: str, output: str) -> None:
         test_name: name of the test and file to save to
         output: test output
     """
-    output_dir = Path("Thriller/tests/outputs")
+    if os.getenv("THRILLER_SAVE_TEST_OUTPUT") != "1":
+        return
+
+    output_dir = Path("tests/outputs")
     output_dir.mkdir(parents=True, exist_ok=True)
     with open(output_dir / f"{test_name}.json", "w") as f:
         json.dump(output, f, indent=2)
 
 
-def load_config(args: Namespace) -> io.TextIOWrapper:
+def load_config(args: Union[Namespace, str]) -> io.TextIOWrapper:
     """
     Open and return the configuration file
     Args:
@@ -35,6 +39,9 @@ def load_config(args: Namespace) -> io.TextIOWrapper:
     Return:
         Opened configuration file
     """
+
+    if isinstance(args, str):
+        args = Namespace(config=args, overrides=None)
 
     argdict = {}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,4 +1,3 @@
-from pathlib import Path
 from unittest.mock import mock_open, patch
 
 import pytest
@@ -38,7 +37,7 @@ def test_generate_response_together(mock_together):
         "temperature": 0.7,
     }
 
-    with patch("together.Together", return_value=mock_together):
+    with patch("src.thriller.api.Together", return_value=mock_together):
         try:
             result = generate_response(messages, model_config)
             # Assert the result
@@ -77,4 +76,3 @@ def test_save_raw_api_output(mock_mkdir, mock_file):
     )
     output = {"response": "test"}
     save_raw_api_output(output=output, filename="test.json", output_path="./outputs/")
-

--- a/tests/test_gerrig.py
+++ b/tests/test_gerrig.py
@@ -178,15 +178,20 @@ def mock_generate_response(messages, model_config):
     exp_name = messages[0]["content"].split(" prompt")[0].strip()
     version_text = messages[1]["content"]
     for version_name, v_text in version_prompts[exp_name]:
-        if v_text == version_text:
+        if version_text.endswith(v_text):
             response = mock_responses.get((exp_name, version_name), "")
             return f"Response: {response}"  # Add a key that can be parsed
     return ""
 
 
-@patch("src.thriller.api.generate_response", side_effect=mock_generate_response)
-@patch("src.thriller.api.save_raw_api_output")
-def test_run_experiment(mock_save_raw_api_output, mock_generate_response):
+@patch("src.thriller.misc.parse_response", return_value={"Q1": "1", "Q2": "2"})
+@patch("src.thriller.misc.generate_response", side_effect=mock_generate_response)
+@patch("src.thriller.misc.save_raw_api_output")
+def test_run_experiment(
+    mock_save_raw_api_output,
+    mock_generate_response,
+    mock_parse_response,
+):
     model_config = {
         "name": "gpt-3",
         "max_tokens": 50,
@@ -195,18 +200,33 @@ def test_run_experiment(mock_save_raw_api_output, mock_generate_response):
         "top_p": 0.9,
         "repetition_penalty": 1.0,
     }
+    parse_model_config = {
+        "api_type": "together",
+        "name": "parser",
+        "max_tokens": 50,
+        "temperature": 0.0,
+    }
     output_path = Path("/fake/path")
 
-    results = run_experiment(output_path, model_config, prompts, version_prompts)
+    results = run_experiment(
+        output_path,
+        model_config,
+        parse_model_config,
+        prompts,
+        version_prompts,
+    )
 
-    assert results == expected_results
+    assert len(results) == len(expected_results)
+    assert all(result["parsed_response"] == {"0": 1, "1": 2} for result in results)
     assert mock_generate_response.call_count == 8
     assert mock_save_raw_api_output.call_count == 8
+    assert mock_parse_response.call_count == 8
 
     save_test_output(
         "test_run_experiment",
         {
             "model_config": model_config,
+            "parse_model_config": parse_model_config,
             "prompts": prompts,
             "version_prompts": version_prompts,
             "results": results,

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -17,8 +17,13 @@ from src.thriller.utils import save_test_output
     "src.thriller.misc.generate_response",
     return_value="Response for Experiment A Version Pen Removed",
 )
+@patch("src.thriller.misc.parse_response", return_value={"Q1": "1"})
 @patch("src.thriller.misc.save_raw_api_output")
-def test_run_experiment(mock_save_raw_api_output, mock_generate_response):
+def test_run_experiment(
+    mock_save_raw_api_output,
+    mock_parse_response,
+    mock_generate_response,
+):
     experiment_series = "gerrig"
     model_config = {
         "name": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
@@ -27,6 +32,12 @@ def test_run_experiment(mock_save_raw_api_output, mock_generate_response):
         # "top_k": 50,
         # "top_p": 0.9,
         # "repetition_penalty": 1.0,
+    }
+    parse_model_config = {
+        "api_type": "together",
+        "name": "parser",
+        "max_tokens": 50,
+        "temperature": 0.0,
     }
     prompts = {"Experiment A": "Prompt A"}
     version_prompts = {
@@ -38,43 +49,30 @@ def test_run_experiment(mock_save_raw_api_output, mock_generate_response):
     }
 
     results = run_experiment(
-        Path(experiment_series), model_config, prompts, version_prompts
-    )
-    results = run_experiment(
-        Path(experiment_series), model_config, prompts, version_prompts
+        Path(experiment_series),
+        model_config,
+        parse_model_config,
+        prompts,
+        version_prompts,
     )
 
-    assert len(results) == 2
+    assert len(results) == 3
     for result in results:
         assert result["experiment_name"] == "Experiment A"
         assert result["version"] in ["Version A1 Name", "Version A2 Name"]
         assert result["raw_response"] == "Response for Experiment A Version Pen Removed"
-        assert (
-            result["parsed_response"] == "Response for Experiment A Version Pen Removed"
-        )
-        assert (
-            result["parsed_response"] == "Response for Experiment A Version Pen Removed"
-        )
+        assert result["parsed_response"] == {"0": 1}
 
-    assert mock_generate_response.call_count == 2
-    assert mock_save_raw_api_output.call_count == 2
+    assert mock_generate_response.call_count == 3
+    assert mock_parse_response.call_count == 3
+    assert mock_save_raw_api_output.call_count == 3
 
     save_test_output(
         "test_run_experiment",
         {
             "experiment_series": experiment_series,
             "model_config": model_config,
-            "prompts": prompts,
-            "version_prompts": version_prompts,
-            "results": results,
-        },
-    )
-
-    save_test_output(
-        "test_run_experiment",
-        {
-            "experiment_series": experiment_series,
-            "model_config": model_config,
+            "parse_model_config": parse_model_config,
             "prompts": prompts,
             "version_prompts": version_prompts,
             "results": results,

--- a/tests/test_run_benchmark.py
+++ b/tests/test_run_benchmark.py
@@ -1,0 +1,147 @@
+import importlib.util
+import json
+import sys
+from dataclasses import replace
+from pathlib import Path
+
+import pytest
+
+
+def load_runner_module():
+    path = Path(__file__).resolve().parents[1] / "scripts" / "run_benchmark.py"
+    spec = importlib.util.spec_from_file_location("run_benchmark", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_final_main_plan_counts_and_paths():
+    runner = load_runner_module()
+
+    plan = runner.build_plan(
+        suite="final-main",
+        experiments=runner.DEFAULT_EXPERIMENTS,
+        repeats=3,
+        model=runner.DEFAULT_MODEL,
+        parse_model=runner.DEFAULT_MODEL,
+    )
+
+    assert len(plan.specs) == 15
+    assert plan.total_calls == 3684
+
+    by_experiment = {(spec.experiment, spec.repeat): spec for spec in plan.specs}
+    assert by_experiment[("gerrig", 1)].expected_calls == 16
+    assert by_experiment[("delatorre", 1)].expected_calls == 192
+    assert by_experiment[("lehne", 1)].expected_calls == 130
+    assert by_experiment[("brewer", 1)].expected_calls == 10
+    assert by_experiment[("bentz", 1)].expected_calls == 880
+
+    lehne = by_experiment[("lehne", 1)]
+    assert lehne.source_augmentation_order == ("distraction_insertion",)
+    assert lehne.augmentation_order == ()
+    assert str(by_experiment[("brewer", 2)].output_dir).endswith(
+        "outputs/brewer_experiment/final/paper/exp2"
+    )
+
+
+def test_final_main_refuses_effective_augmentation():
+    runner = load_runner_module()
+    plan = runner.build_plan(
+        suite="final-main",
+        experiments=("lehne",),
+        repeats=1,
+        model=runner.DEFAULT_MODEL,
+        parse_model=runner.DEFAULT_MODEL,
+    )
+    unsafe_spec = replace(plan.specs[0], augmentation_order=("distraction_insertion",))
+
+    with pytest.raises(ValueError, match="Refusing final-main"):
+        runner.validate_run_spec(unsafe_spec)
+
+
+def test_effective_config_forces_model_output_and_control_augmentation():
+    runner = load_runner_module()
+    plan = runner.build_plan(
+        suite="final-main",
+        experiments=("lehne",),
+        repeats=2,
+        model=runner.DEFAULT_MODEL,
+        parse_model=runner.DEFAULT_MODEL,
+    )
+
+    config = runner.effective_config_for_spec(plan.specs[0])
+
+    assert config["model"]["name"] == runner.DEFAULT_MODEL
+    assert config["parse_model"]["name"] == runner.DEFAULT_MODEL
+    assert config["augmentation"]["augmentation_order"] == []
+    assert config["experiment"]["output_dir"].endswith("outputs/lehne_experiment/final/e1")
+
+
+def test_output_state_blocks_partial_dirs_and_resumes_completed(tmp_path):
+    runner = load_runner_module()
+    plan = runner.build_plan(
+        suite="final-main",
+        experiments=("gerrig",),
+        repeats=1,
+        model=runner.DEFAULT_MODEL,
+        parse_model=runner.DEFAULT_MODEL,
+    )
+    spec = replace(plan.specs[0], output_dir=tmp_path / "outputs" / "gerrig")
+
+    action, completed = runner.ensure_output_state(spec, resume=False)
+    assert action == "run"
+    assert completed is None
+
+    partial_dir = runner.model_output_dir(spec) / "20260420_partial"
+    partial_dir.mkdir(parents=True)
+    with pytest.raises(RuntimeError, match="Existing output dirs"):
+        runner.ensure_output_state(spec, resume=True)
+
+    completed_spec = replace(
+        plan.specs[0], output_dir=tmp_path / "outputs" / "gerrig_completed"
+    )
+    run_dir = runner.model_output_dir(completed_spec) / "20260420_completed"
+    run_dir.mkdir(parents=True)
+    (run_dir / "results.csv").write_text("experiment_name,version,response\nA,B,{}\n")
+    manifest = runner.manifest_payload(
+        spec=completed_spec,
+        run_dir=run_dir,
+        status="completed",
+        started_at="2026-04-20T00:00:00+00:00",
+        finished_at="2026-04-20T00:00:01+00:00",
+        actual_rows=completed_spec.expected_rows,
+    )
+    (run_dir / "benchmark_manifest.json").write_text(json.dumps(manifest))
+
+    action, completed = runner.ensure_output_state(completed_spec, resume=True)
+    assert action == "skip"
+    assert completed == run_dir
+
+    with pytest.raises(RuntimeError, match="Completed output already exists"):
+        runner.ensure_output_state(completed_spec, resume=False)
+
+
+def test_write_manifest_fails_on_null_parsed_values(tmp_path):
+    runner = load_runner_module()
+    plan = runner.build_plan(
+        suite="final-main",
+        experiments=("lehne",),
+        repeats=1,
+        model=runner.DEFAULT_MODEL,
+        parse_model=runner.DEFAULT_MODEL,
+    )
+    spec = plan.specs[0]
+    run_dir = tmp_path / "run"
+    run_dir.mkdir()
+    (run_dir / "results.csv").write_text(
+        "experiment_name,version,response\n"
+        "\"Experiment\",\"Normal\",\"{'0': 5, '1': None}\"\n"
+    )
+
+    with pytest.raises(RuntimeError, match="Result quality check failed"):
+        runner.write_manifest(spec, run_dir, "2026-04-20T00:00:00+00:00")
+
+    manifest = json.loads((run_dir / "benchmark_manifest.json").read_text())
+    assert manifest["status"] == "failed"
+    assert manifest["quality_issues"][0]["bad_values"] == {"1": None}

--- a/tests/test_thriller.py
+++ b/tests/test_thriller.py
@@ -1,29 +1,24 @@
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 
 from src.thriller.Thriller import main as main_func
 from src.thriller.Thriller import parse_arguments
+from src.thriller.Thriller import run_config
 from src.thriller.utils import save_test_output
 
 
-@patch("together.Together")
-@patch("src.thriller.misc.run_experiment")
-@patch("src.thriller.utils.process_and_save_results")
-@patch("src.thriller.utils.load_config")
-@patch("os.getenv")
+@patch("src.thriller.Thriller.run_experiment", return_value=[])
+@patch("src.thriller.Thriller.process_and_save_results")
+@patch("src.thriller.Thriller.write_prompt_snapshots")
+@patch("src.thriller.Thriller.load_config")
+@patch("src.thriller.Thriller.os.getenv")
 def test_thriller(
-    mock_together,
     mock_getenv,
     mock_load_config,
+    mock_write_prompt_snapshots,
     mock_process_and_save_results,
     mock_run_experiment,
 ):
-    # Mock the API key in the environment
-    mock_together_instance = MagicMock()
-    mock_together.return_value = mock_together_instance
-    mock_together_instance.chat.completions.create.return_value = MagicMock(
-        choices=[MagicMock(message=MagicMock(content="This is a mocked response."))]
-    )
     mock_getenv.return_value = "TOGETHER_API_KEY"
     mock_config = {
         "model": {
@@ -35,34 +30,27 @@ def test_thriller(
             "top_p": 0.9,
             "repetition_penalty": 1.0,
         },
+        "parse_model": {
+            "api_type": "together",
+            "name": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "prompt": "Parse the response.",
+            "max_tokens": 50,
+            "temperature": 0.0,
+            "top_p": 0.9,
+            "repetition_penalty": 1.0,
+        },
         "experiment": {
             "experiment_series": "gerrig",
+            "use_alternative": False,
             "output_dir": "./outputs/",
         },
+        "augmentation": {"augmentation_order": []},
     }
     mock_load_config.return_value = mock_config
 
     test_args = [
         "--config",
         "config.yaml",
-        "--api_type",
-        "together",
-        "--model",
-        "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        "--max_tokens",
-        "50",
-        "--temperature",
-        "0.7",
-        "--top_k",
-        "50",
-        "--top_p",
-        "0.9",
-        "--repetition_penalty",
-        "1.0",
-        "--experiment_series",
-        "gerrig",
-        "--output_dir",
-        "./outputs/",
     ]
 
     with patch("sys.argv", ["pytest"] + test_args):
@@ -83,6 +71,50 @@ def test_thriller(
     assert call_args["model_config"]["api_key"] == "TOGETHER_API_KEY"
     assert call_args["model_config"]["api_type"] == "together"
     mock_process_and_save_results.assert_called_once()
+    mock_write_prompt_snapshots.assert_called_once()
+
+
+@patch("src.thriller.Thriller.run_experiment")
+@patch("src.thriller.Thriller.write_prompt_snapshots")
+@patch("src.thriller.Thriller.os.getenv")
+def test_run_config_dry_run_skips_writes_and_execution(
+    mock_getenv,
+    mock_write_prompt_snapshots,
+    mock_run_experiment,
+):
+    mock_getenv.return_value = "TOGETHER_API_KEY"
+    config = {
+        "model": {
+            "api_type": "together",
+            "name": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "max_tokens": 50,
+            "temperature": 0.7,
+            "top_k": 50,
+            "top_p": 0.9,
+            "repetition_penalty": 1.0,
+        },
+        "parse_model": {
+            "api_type": "together",
+            "name": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "prompt": "Parse the response.",
+            "max_tokens": 50,
+            "temperature": 0.0,
+            "top_p": 0.9,
+            "repetition_penalty": 1.0,
+        },
+        "experiment": {
+            "experiment_series": "gerrig",
+            "use_alternative": False,
+            "output_dir": "./outputs/",
+        },
+        "augmentation": {"augmentation_order": []},
+    }
+
+    output_paths = run_config(config, write_prompts=False, dry_run=True)
+
+    assert output_paths == []
+    mock_write_prompt_snapshots.assert_not_called()
+    mock_run_experiment.assert_not_called()
 
 
 
@@ -91,52 +123,22 @@ def test_parse_arguments():
         "test_parse_arguments_input",
         {
             "test_args": [
-                "--model",
-                "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-                "--max_tokens",
-                "50",
-                "--temperature",
-                "0.7",
-                "--top_k",
-                "50",
-                "--top_p",
-                "0.9",
-                "--repetition_penalty",
-                "1.0",
-                "--experiment_series",
-                "gerrig",
-                "--output_dir",
-                "./outputs/",
+                "--config",
+                "configs/gerrig.yaml",
+                "--overrides",
+                "model.temperature=0.7",
             ]
         },
     )
     test_args = [
-        "--model",
-        "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-        "--max_tokens",
-        "50",
-        "--temperature",
-        "0.7",
-        "--top_k",
-        "50",
-        "--top_p",
-        "0.9",
-        "--repetition_penalty",
-        "1.0",
-        "--experiment_series",
-        "gerrig",
-        "--output_dir",
-        "./outputs/",
+        "--config",
+        "configs/gerrig.yaml",
+        "--overrides",
+        "model.temperature=0.7",
     ]
 
     with patch("sys.argv", ["pytest"] + test_args):
         args = parse_arguments()
 
-    assert args.model == "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo"
-    assert args.max_tokens == 50
-    assert args.temperature == 0.7
-    assert args.top_k == 50
-    assert args.top_p == 0.9
-    assert args.repetition_penalty == 1.0
-    assert args.experiment_series == "gerrig"
-    assert args.output_dir == "./outputs/"
+    assert args.config == "configs/gerrig.yaml"
+    assert args.overrides == ["model.temperature=0.7"]

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -24,8 +24,7 @@ def test_load_config():
 
 
 @patch("pandas.DataFrame.to_csv")
-@patch("pandas.DataFrame.to_parquet")
-def test_process_and_save_results(mock_to_parquet, mock_to_csv):
+def test_process_and_save_results(mock_to_csv):
     results = [
         {
             "experiment_name": "Experiment A",
@@ -41,6 +40,3 @@ def test_process_and_save_results(mock_to_parquet, mock_to_csv):
     df = process_and_save_results(results=results, output_path="./outputs/")
     assert isinstance(df, pd.DataFrame)
     mock_to_csv.assert_called_once_with(Path("outputs/results.csv"), index=False)
-    mock_to_parquet.assert_called_once_with(
-        Path("outputs/results.parquet"), index=False
-    )


### PR DESCRIPTION
## Summary

- Refactor the Thriller CLI path into reusable experiment preparation and `run_config` execution helpers.
- Add a paper-style benchmark runner with planning, resume checks, manifests, preflight API support, and result-quality failure detection.
- Update API/parsing behavior and optional adversarial dependencies so local tests and smoke execution do not require the full NLP stack unless those augmentations are used.
- Expand tests around runner planning, output safety, parsing behavior, prompt generation, and API response extraction.

## Why

The previous run path was hard to orchestrate safely for full benchmark runs: it mixed CLI-only behavior, prompt snapshot writes, API key attachment, output directory creation, and execution. The new runner gives us a repeat-aware, manifest-backed workflow that can dry-run plans, resume completed runs, and fail fast on partial or malformed outputs.

## Validation

- `uv run ruff check src tests conftest.py scripts/run_benchmark.py`
- `uv run pytest tests/` -> 20 passed, 1 existing pydantic deprecation warning

## Notes

Generated benchmark outputs and quarantined partial runs remain local and are not included in this PR.